### PR TITLE
Utilize Different Font Types to Bypass All GPT Detectors 

### DIFF
--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -2,12 +2,11 @@ import random
 
 def replace_letters(file_buffer):
     # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace('a', 'а')
-    file_buffer = file_buffer.replace('e', 'е')
-    file_buffer = file_buffer.replace('o', 'о')
-    file_buffer = file_buffer.replace('A', 'А')
-    file_buffer = file_buffer.replace('E', 'Е')
-    file_buffer = file_buffer.replace('O', 'О')
+    file_buffer = file_buffer.replace('T', 'T')
+    file_buffer = file_buffer.replace('i', 'i')
+    file_buffer = file_buffer.replace('m', 'm')
+    file_buffer = file_buffer.replace('e', 'e')
+    file_buffer = file_buffer.replace('s', 's')
     return file_buffer
 
 def insert_zwj(file_buffer):

--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -2,11 +2,7 @@ import random
 
 def replace_letters(file_buffer):
     # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace('T', 'T')
-    file_buffer = file_buffer.replace('i', 'i')
-    file_buffer = file_buffer.replace('m', 'm')
-    file_buffer = file_buffer.replace('e', 'e')
-    file_buffer = file_buffer.replace('s', 's')
+    file_buffer = file_buffer.replace(' ', '‎ ')
     return file_buffer
 
 def insert_zwj(file_buffer):

--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -2,7 +2,7 @@ import random
 
 def replace_letters(file_buffer):
     # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace(' ', '​')
+    file_buffer = file_buffer.replace(' ', ' ')
     return file_buffer
 
 def insert_zwj(file_buffer):

--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -1,29 +1,35 @@
 import random
 
-def replace_letters(file_buffer):
-    # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace('a', '𝚊')
-    file_buffer = file_buffer.replace('q', '𝚚')
-    file_buffer = file_buffer.replace('u', '𝚞')
-    file_buffer = file_buffer.replace('n', '𝚗')
-    file_buffer = file_buffer.replace('t', '𝚝')
-    file_buffer = file_buffer.replace('m', '𝚖')
-    file_buffer = file_buffer.replace('c', '𝚌')
-    file_buffer = file_buffer.replace('o', '𝚘')
-    file_buffer = file_buffer.replace('l', '𝚕 ')
-    return file_buffer
+CYRILLIC_MAP = {
+    'a': '𝚊',
+    'q': '𝚚',
+    'u': '𝚞',
+    'n': '𝚗',
+    't': '𝚝',
+    'm': '𝚖',
+    'c': '𝚌',
+    'o': '𝚘',
+    'l': '𝚕 '
+}
 
-def insert_zwj(file_buffer):
+ZWJ_PROBABILITY = 0.2
+
+def replace_letters(input_text):
     output = ""
-    zwj = "\u200D" # Zero Width Joiner unicode character
-    for char in file_buffer:
+    for char in input_text:
+        output += CYRILLIC_MAP.get(char, char)
+    return output
+
+def insert_zwj(input_text):
+    output = ""
+    zwj = "\u200D"
+    for char in input_text:
         output += char
-        # Randomly insert zero width joiner
-        if random.random() < 0.2: # Lower number = Less ZWJ
+        if random.random() < ZWJ_PROBABILITY:
             output += zwj
     return output
 
-
-print(insert_zwj(replace_letters(input())))
-
-input()
+input_text = input("Enter the text: ")
+cyrillic_text = replace_letters(input_text)
+output_text = insert_zwj(cyrillic_text)
+print("Output text: ", output_text)

--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -2,7 +2,7 @@ import random
 
 def replace_letters(file_buffer):
     # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace(' ', '‎ ')
+    file_buffer = file_buffer.replace(' ', '​')
     return file_buffer
 
 def insert_zwj(file_buffer):

--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -2,7 +2,7 @@ import random
 
 def replace_letters(file_buffer):
     # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace(' ', ' ')
+    file_buffer = file_buffer.replace(' ', '᲼')
     return file_buffer
 
 def insert_zwj(file_buffer):

--- a/GPTZero-Bypasser.py
+++ b/GPTZero-Bypasser.py
@@ -2,7 +2,15 @@ import random
 
 def replace_letters(file_buffer):
     # Changes all AEOaeo letters with the cyrillic varients.
-    file_buffer = file_buffer.replace(' ', '᲼')
+    file_buffer = file_buffer.replace('a', '𝚊')
+    file_buffer = file_buffer.replace('q', '𝚚')
+    file_buffer = file_buffer.replace('u', '𝚞')
+    file_buffer = file_buffer.replace('n', '𝚗')
+    file_buffer = file_buffer.replace('t', '𝚝')
+    file_buffer = file_buffer.replace('m', '𝚖')
+    file_buffer = file_buffer.replace('c', '𝚌')
+    file_buffer = file_buffer.replace('o', '𝚘')
+    file_buffer = file_buffer.replace('l', '𝚕 ')
     return file_buffer
 
 def insert_zwj(file_buffer):

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # GPTZero-Bypasser
 
-Takes any AI-written text that would be detected by GPTZero and makes it magically 'not AI written'.
+Takes any AI-written text that would be detected by [GPTZero](https://gptzero.me/) and makes it magically 'not AI written'.
 
 ## Demo
 

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,3 @@ GPTZero thinks:
 After using the script, GPTZero thinks:
 
 `Your text is likely to be written entirely by a human.`
-
-
-
-## Usage
-
-You can F5-Run it in idle if you want, but if you just run it normally, an empty terminal opens. Copy-paste your text into the terminal and press Enter, then copy the new text from the terminal.
-
-**This removes all formatting. Sorry! :)**
-
-Made in Python 3.8

--- a/readme.md
+++ b/readme.md
@@ -16,3 +16,7 @@ GPTZero thinks:
 After using the script, GPTZero thinks:
 
 `Your text is likely to be written entirely by a human.`
+
+## Usage:
+
+Website: https://gonzoknows.com/posts/Bypass-GPTZero-Using-Different-Fonts/


### PR DESCRIPTION
As demonstrated here: https://gonzoknows.com/posts/Bypass-GPTZero-Using-Different-Fonts/

https://www.youtube.com/shorts/XplpSKtRBzw

I've tested this method against the following GPT detect programs, and it bypasses with flying colors:
- GPTZero
- ChatGPT Official AI Text Identifiers 

Closes #2 